### PR TITLE
Change Enums to be more friendly towards global intialization

### DIFF
--- a/src/main/kotlin/dev/znci/twine/TwineEnum.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineEnum.kt
@@ -27,6 +27,7 @@ class TwineEnum(private val enum: Enum<*>) : TwineTable(enum.javaClass.simpleNam
     fun toLuaTable(): LuaTable {
         val table = this.table
         for (enumConstant in enum.javaClass.enumConstants) {
+            // FIXME: figure out why we can't use TwineLuaValue.
             table.set(enumConstant.name, LuaValue.valueOf(enumConstant.ordinal))
         }
         return table

--- a/src/main/kotlin/dev/znci/twine/TwineEnum.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineEnum.kt
@@ -2,10 +2,28 @@ package dev.znci.twine
 
 import org.luaj.vm2.LuaTable
 import org.luaj.vm2.LuaValue
-import kotlin.reflect.KClass
 
-class TwineEnum(name: String) : TwineTable(name) {
-    fun toLuaTable(enum: Enum<*>): LuaTable {
+class TwineEnum(private val enum: Enum<*>) : TwineTable(enum.javaClass.simpleName) {
+
+    init {
+        val table = this.table
+        table.setmetatable(LuaTable())
+        table.set("__index", object : LuaValue() {
+            override fun type(): Int = TTABLE
+            override fun typename(): String = "table"
+            override fun call(key: LuaValue): LuaValue {
+                return table.get(key)
+            }
+        })
+        table.set("__index", object : LuaValue() {
+            override fun type(): Int = TTABLE
+            override fun typename(): String = "table"
+            override fun call(key: LuaValue, value: LuaValue): LuaValue {
+                throw TwineError("Enum values cannot be set")
+            }
+        })
+    }
+    fun toLuaTable(): LuaTable {
         val table = this.table
         for (enumConstant in enum.javaClass.enumConstants) {
             table.set(enumConstant.name, TwineLuaValue(LuaValue.valueOf(enumConstant.ordinal)))
@@ -13,8 +31,8 @@ class TwineEnum(name: String) : TwineTable(name) {
         return table
     }
 
-    fun fromLuaTable(luaTable: LuaTable, enum: KClass<out Any>): Enum<*> {
-        val enumConstants = enum.java.enumConstants
+    fun fromLuaTable(luaTable: LuaTable): Enum<*> {
+        val enumConstants = enum.javaClass.enumConstants
         for (i in 0 until luaTable.length()) {
             val name = luaTable[i + 1].toString()
             for (enumConstant in enumConstants as Array<Enum<*>>) {

--- a/src/main/kotlin/dev/znci/twine/TwineEnum.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineEnum.kt
@@ -23,10 +23,11 @@ class TwineEnum(private val enum: Enum<*>) : TwineTable(enum.javaClass.simpleNam
             }
         })
     }
+
     fun toLuaTable(): LuaTable {
         val table = this.table
         for (enumConstant in enum.javaClass.enumConstants) {
-            table.set(enumConstant.name, TwineLuaValue(LuaValue.valueOf(enumConstant.ordinal)))
+            table.set(enumConstant.name, LuaValue.valueOf(enumConstant.ordinal))
         }
         return table
     }

--- a/src/main/kotlin/dev/znci/twine/TwineNative.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineNative.kt
@@ -243,8 +243,8 @@ abstract class TwineNative(
             }
             is Enum<*> -> {
                 val enumClass = this::class
-                val enumTable = TwineEnum(enumClass.simpleName!!)
-                enumTable.toLuaTable(this)
+                val enumTable = TwineEnum(enumClass as Enum<*>)
+                enumTable.toLuaTable()
             }
             is Unit -> {
                 throw TwineError("Unit return type is not allowed. At least return a Boolean.")
@@ -290,8 +290,9 @@ abstract class TwineNative(
 
             // if enum class
             if (clazz.java.isEnum) {
-                val renum = TwineEnum(clazz.simpleName!!)
-                return renum.fromLuaTable(this, clazz)
+                // get Enum<*> class
+                val renum = TwineEnum(clazz as Enum<*>)
+                return renum.fromLuaTable(this)
             } else {
                 val constructor =
                     clazz.primaryConstructor

--- a/src/test/kotlin/dev/znci/twine/TwineEnumTest.kt
+++ b/src/test/kotlin/dev/znci/twine/TwineEnumTest.kt
@@ -1,0 +1,117 @@
+package dev.znci.twine
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.luaj.vm2.LuaTable
+import org.luaj.vm2.LuaValue
+
+class TwineEnumTest {
+
+    /**
+     * Class being tested: TwineEnum
+     *
+     * Description:
+     * The TwineEnum class wraps an Enum and exposes functionality for converting the Enum to a LuaTable.
+     * The `toLuaTable()` method converts enum constants to a LuaTable where each constant is a field
+     * with the name of the enum constant as the key, and its ordinal as the value.
+     */
+
+    private enum class SampleEnum {
+        FIRST, SECOND, THIRD
+    }
+
+    @Test
+    fun `toLuaTable should convert an enum with multiple constants to a LuaTable`() {
+        // Arrange
+        val enum = SampleEnum.entries[0]
+        val twineEnum = TwineEnum(enum)
+
+        // Act
+        val luaTable = twineEnum.toLuaTable()
+
+        // Assert
+        assertEquals(4, luaTable.keys().size) // 4, including the __javaClass key
+        assertEquals(LuaValue.valueOf(0), luaTable.get("FIRST"))
+        assertEquals(LuaValue.valueOf(1), luaTable.get("SECOND"))
+        assertEquals(LuaValue.valueOf(2), luaTable.get("THIRD"))
+    }
+
+    @Test
+    fun `fromLuaTable should convert a LuaTable with multiple constants back to the corresponding enum value`() {
+        // Arrange
+        val enum = SampleEnum.FIRST
+        val twineEnum = TwineEnum(enum)
+        val luaTable = LuaTable()
+        luaTable.set(1, LuaValue.valueOf("SECOND"))
+
+        // Act
+        val result = twineEnum.fromLuaTable(luaTable)
+
+        // Assert
+        assertEquals(SampleEnum.SECOND, result)
+    }
+
+    @Test
+    fun `fromLuaTable should properly handle a LuaTable with a single constant`() {
+        // Arrange
+        val enum = SingleValueEnum.FIRST
+        val twineEnum = TwineEnum(enum)
+        val luaTable = LuaTable()
+        luaTable.set(1, LuaValue.valueOf("FIRST"))
+
+        // Act
+        val result = twineEnum.fromLuaTable(luaTable)
+
+        // Assert
+        assertEquals(SingleValueEnum.FIRST, result)
+    }
+
+    @Test
+    fun `fromLuaTable should throw TwineError if the LuaTable contains an invalid enum constant`() {
+        // Arrange
+        val enum = SampleEnum.FIRST
+        val twineEnum = TwineEnum(enum)
+        val luaTable = LuaTable()
+        luaTable.set(1, LuaValue.valueOf("INVALID_CONSTANT"))
+
+        // Act & Assert
+        val exception = assertThrows<TwineError> {
+            twineEnum.fromLuaTable(luaTable)
+        }
+        assertEquals("Enum constant not found", exception.message)
+    }
+
+    @Test
+    fun `toLuaTable should handle an enum with a single constant correctly`() {
+        // Arrange
+        val enum = SingleValueEnum.FIRST
+        val twineEnum = TwineEnum(enum)
+
+        // Act
+        val luaTable = twineEnum.toLuaTable()
+
+        // Assert
+        assertEquals(2, luaTable.keys().size) // 2, including the __javaClass key
+        assertEquals(LuaValue.valueOf(0), luaTable.get("FIRST"))
+    }
+
+    @Test
+    fun `toLuaTable should handle an empty enum correctly`() {
+        // Arrange
+        val enum = EmptyEnum.entries.firstOrNull() ?: return
+        val twineEnum = TwineEnum(enum)
+
+        // Act
+        val luaTable = twineEnum.toLuaTable()
+
+        // Assert
+        assertEquals(0, luaTable.keys().size)
+    }
+
+    private enum class SingleValueEnum {
+        FIRST
+    }
+
+    private enum class EmptyEnum
+}


### PR DESCRIPTION
This PR makes it so that Enums can be globally registered, using some sort of global initializer system like the one found in Rocket.