### PR TITLE
Add vararg support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.znci"
-version = "1.0.5"
+version = "1.0.6"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/znci/twine/TwineNative.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineNative.kt
@@ -236,8 +236,8 @@ abstract class TwineNative(
     private fun Varargs.toKotlinArgs(func: KFunction<*>): Array<Any?> {
         val params = func.parameters.drop(1) // Skip `this`
 
-        val firstParam = params.firstOrNull()
-        val isVararg = firstParam?.isVararg == true
+        val lastParam = params.lastOrNull()
+        val isVararg = lastParam?.isVararg == true
         val fixedParamCount = if (isVararg) params.size - 1 else params.size
 
         if (narg() < fixedParamCount) {
@@ -248,19 +248,19 @@ abstract class TwineNative(
             throw TwineError("Invalid number of arguments for ${func.name}. Expected ${fixedParamCount}, got ${narg()}")
         }
 
-        if (firstParam?.isVararg == true) {
+        if (lastParam?.isVararg == true) {
             val firstArg = this.arg(1)
             val firstArgType = firstArg.toKotlinType(func)
-            val count = narg() - 1
+            val count = narg()
 
             val firstArgArray: Any = when (firstArgType.classifier) {
-                Double::class -> List(count) { this.arg(it + 2).todouble() }.toDoubleArray()
-                Boolean::class -> List(count) { this.arg(it + 2).toboolean() }.toBooleanArray()
-                Int::class -> List(count) { this.arg(it + 2).toint() }.toIntArray()
-                Float::class -> List(count) { this.arg(it + 2).tofloat() }.toFloatArray()
-                Long::class -> List(count) { this.arg(it + 2).tolong() }.toLongArray()
-                String::class -> Array(count) { this.arg(it + 2).tojstring() }
-                LuaValue::class -> Array(count) { this.arg(it + 2) }
+                Double::class -> List(count) { this.arg(it + 1).todouble() }.toDoubleArray()
+                Boolean::class -> List(count) { this.arg(it + 1).toboolean() }.toBooleanArray()
+                Int::class -> List(count) { this.arg(it + 1).toint() }.toIntArray()
+                Float::class -> List(count) { this.arg(it + 1).tofloat() }.toFloatArray()
+                Long::class -> List(count) { this.arg(it + 1).tolong() }.toLongArray()
+                String::class -> Array(count) { this.arg(it + 1).tojstring() }
+                LuaValue::class -> Array(count) { this.arg(it + 1) }
 
                 else -> throw TwineError("Unsupported vararg type: $firstArgType")
             }

--- a/src/main/kotlin/dev/znci/twine/TwineNative.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineNative.kt
@@ -254,9 +254,9 @@ abstract class TwineNative(
             val count = narg()
 
             val firstArgArray: Any = when (firstArgType.classifier) {
+                Int::class -> List(count) { this.arg(it + 1).toint() }.toIntArray().toTypedArray()
                 Double::class -> List(count) { this.arg(it + 1).todouble() }.toDoubleArray()
                 Boolean::class -> List(count) { this.arg(it + 1).toboolean() }.toBooleanArray()
-                Int::class -> List(count) { this.arg(it + 1).toint() }.toIntArray()
                 Float::class -> List(count) { this.arg(it + 1).tofloat() }.toFloatArray()
                 Long::class -> List(count) { this.arg(it + 1).tolong() }.toLongArray()
                 String::class -> Array(count) { this.arg(it + 1).tojstring() }

--- a/src/main/kotlin/dev/znci/twine/TwineNative.kt
+++ b/src/main/kotlin/dev/znci/twine/TwineNative.kt
@@ -118,7 +118,7 @@ abstract class TwineNative(
                         val argCount = args.narg()
                         val matchingFunction = overloadedFunctions.find { function ->
                             val params = function.parameters.drop(1) // Skip `this`
-                             val isVararg = params.lastOrNull()?.isVararg == true
+                            val isVararg = params.lastOrNull()?.isVararg == true
                             val fixedParamCount = if (isVararg) params.size - 1 else params.size
 
                             if (argCount < fixedParamCount) return@find false

--- a/src/test/kotlin/dev/znci/twine/TwineNativeTest.kt
+++ b/src/test/kotlin/dev/znci/twine/TwineNativeTest.kt
@@ -1,0 +1,56 @@
+package dev.znci.twine
+
+import dev.znci.twine.annotations.TwineNativeFunction
+import org.junit.jupiter.api.Test
+import org.luaj.vm2.Globals
+import org.luaj.vm2.lib.jse.JsePlatform
+import kotlin.test.assertEquals
+
+class TwineNativeTestClass: TwineNative("") {
+    @TwineNativeFunction
+    fun testVarargStr(vararg args: String): String {
+        return args.joinToString(", ")
+    }
+    @TwineNativeFunction
+    fun testVarargDouble(vararg args: Double): Double {
+        return args.sumOf { it.toDouble() }
+    }
+    @TwineNativeFunction
+    fun testVarargBool(vararg args: Boolean): String {
+        return args.joinToString(", ")
+    }
+}
+
+class TwineNativeTest {
+    fun run(script: String): Any {
+        val globals: Globals = JsePlatform.standardGlobals()
+
+        val twineNative = TwineNativeTestClass()
+        globals.set("test", twineNative.table)
+
+        val result = globals.load(script, "test.lua").call()
+
+        return result
+    }
+
+    @Test
+    fun `testVarargStr should print the arguments passed to it`() {
+        val result = run("return test.testVarargStr('Hello', 'World')")
+
+        assertEquals("Hello, World", result.toString())
+    }
+
+    @Test
+    fun `testVarargDouble should print the sum of all arguments`() {
+        val result = run("return test.testVarargDouble(1, 2, 3)")
+
+        assertEquals(6, result.toString().toInt())
+    }
+
+    @Test
+    fun `testVarargBool should print the arguments passed to it`() {
+        val result = run("return test.testVarargBool(true, false, true)")
+
+        assertEquals("true, false, true", result.toString())
+    }
+}


### PR DESCRIPTION
This PR solves one of the *final* standing twine issues. I have added a decent vararg system that I can confirm works in my testing. This would also fix the math.min/max functions in https://github.com/LuaRocket/rocket/pull/41, and would allow many more possibilities.