### PR TITLE
feat: add TwineEngine#load (+bump to v2.2.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "computer.obscure"
-version = "2.2.0"
+version = "2.2.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
+++ b/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
@@ -60,6 +60,24 @@ class TwineEngine {
     }
 
     /**
+     * Works functionally the same as LuaJ's default `Globals#load(LuaValue)` function.
+     * Loads a [LuaValue] into the globals table.
+     *
+     * Example:
+     * ```
+     * engine.load(PackageLib())
+     * engine.load(Bit32Lib())
+     * engine.load(TableLib())
+     * engine.load(CoroutineLib())
+     * engine.load(JseMathLib())
+     * engine.load(LuajavaLib())
+     * ```
+     */
+    fun load(library: LuaValue) {
+        globals.load(library)
+    }
+
+    /**
      * Runs a script and returns the result.
      */
     fun run(name: String, content: String): LuaValue {


### PR DESCRIPTION
Adds `load(LuaValue)` to the TwineEngine, works functionally identically to `Globals.load()` in normal LuaJ.
```kt
engine.load(PackageLib())
engine.load(Bit32Lib())
engine.load(TableLib())
engine.load(CoroutineLib())
engine.load(JseMathLib())
engine.load(LuajavaLib())
```