### PR TITLE
feat: more functions in TwineEngine (slight run() refactor)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "computer.obscure"
-version = "2.2.1"
+version = "2.2.2"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/computer/obscure/twine/TwineBaseTest.kt
+++ b/src/test/kotlin/computer/obscure/twine/TwineBaseTest.kt
@@ -30,7 +30,9 @@ class TwineBaseTest {
         val twineNative = TwineBaseTestClass()
         engine.setBase(twineNative)
 
-        return engine.run("test.lua", script)
+        return engine
+            .run("test.lua", script)
+            .getOrThrow()
     }
 
     @Test


### PR DESCRIPTION
adds various new methods:
- clear() - wipes the globals in the TwineEngine instance
- has(String) - checks if the globals contains a LuaValue by that name
- has(TwineNative) - checks if the globals contains a LuaValue by the name of the TwineNative
- get(String) - get a LuaValue from the globals by its name
- get(String) - get a LuaValue from the globals by the name of a TwineNative
- set(vararg TwineNative) - adds a vararg list of TwineNatives into the globals
- remove(String) - removes a LuaValue from the globals by name
- remove(native) - removes a LuaValue from the globals by a TwineNative
- remove(vararg TwineNative) - removes a list of LuaValues by a list of TwineNatives from the globals
- setBase(vararg TwineNative) - adds a list of natives to the base globals
- runSafe(String, String) - runs a script with error handling, returns a Result
- runUnsafe(String, String) - runs a script with no error handling
- run(String, String) - now uses runSafe under the hood, returns a Result (add `.getOrThrow()` after `.run(smth, smth)`)
- withGlobals(block of Globals):
```kt
engine.withGlobals {
  set("debug", LuaValue.TRUE)
}
```

next thing to do will probably just be migrating all the tests to use the new TwineEngine