### PR TITLE
Add more descriptive error messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "computer.obscure"
-version = "2.2.2"
+version = "2.2.3"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
+++ b/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
@@ -9,11 +9,14 @@ class TwineEngine {
     private var _globals: Globals = JsePlatform.standardGlobals()
     val globals: Globals get() = _globals
 
+    /**
+     * A regex list containing replacements for traditional LuaJ error messages.
+     */
     val errorHandlers: List<Pair<Regex, (MatchResult, String, String) -> String>> = listOf(
         // "attempt to index ?" errors
         Regex("""attempt to index \? \(a nil value\)""") to { _, scriptName, rawMessage ->
             val line = rawMessage.substringAfter(":").substringBefore(" ")
-            "Lua error in $scriptName:$line – attempted to index a nil value"
+            "Lua error in $scriptName:$line — attempted to index a nil value"
         },
     )
 

--- a/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
+++ b/src/main/kotlin/computer/obscure/twine/nativex/TwineEngine.kt
@@ -9,6 +9,14 @@ class TwineEngine {
     private var _globals: Globals = JsePlatform.standardGlobals()
     val globals: Globals get() = _globals
 
+    val errorHandlers: List<Pair<Regex, (MatchResult, String, String) -> String>> = listOf(
+        // "attempt to index ?" errors
+        Regex("""attempt to index \? \(a nil value\)""") to { _, scriptName, rawMessage ->
+            val line = rawMessage.substringAfter(":").substringBefore(" ")
+            "Lua error in $scriptName:$line – attempted to index a nil value"
+        },
+    )
+
     /**
      * Wipes the globals using a given [Globals] instance.
      *
@@ -176,7 +184,15 @@ class TwineEngine {
         return try {
             Result.success(runUnsafe(name, content))
         } catch (e: Exception) {
-            Result.failure(e)
+            val rawMessage = e.message ?: "Unknown LuaError"
+
+            val newMessage = errorHandlers.firstOrNull { (regex, _) ->
+                regex.containsMatchIn(rawMessage)
+            }?.let { (regex, handler) ->
+                handler(regex.find(rawMessage)!!, name, rawMessage)
+            } ?: rawMessage
+
+            Result.failure(TwineError(newMessage))
         }
     }
 

--- a/src/test/kotlin/computer/obscure/twine/TwineErrorTest.kt
+++ b/src/test/kotlin/computer/obscure/twine/TwineErrorTest.kt
@@ -1,0 +1,31 @@
+package computer.obscure.twine
+
+import computer.obscure.twine.nativex.TwineEngine
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class TwineErrorTest {
+    fun run(script: String): Any {
+        val engine = TwineEngine()
+
+        val twineNative = TwineBaseTestClass()
+        engine.setBase(twineNative)
+
+        return engine
+            .run("test.lua", script)
+            .getOrThrow()
+    }
+
+    @Test
+    fun `testBaseMethod should throw`() {
+        val exception = assertThrows<TwineError> {
+            run("return test.test")
+        }
+
+        assertEquals(
+            "Lua error in test.lua:1 – attempted to index a nil value",
+            exception.message
+        )
+    }
+}


### PR DESCRIPTION
I have taken it upon myself to add some nicer error messages in replacement of the default ones in LuaJ.

Now, instead of seeing: `attempt to index ? (a nil value)` you see: `Lua error in script:line - attempted to index a nil value`. Due to engine limitations, I am not able to provide the property that was indexed. Unfortunate but I wish to change this later.