### PR TITLE
Release 2.3.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "computer.obscure"
-version = "2.3.1"
+version = "2.3.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/computer/obscure/twine/nativex/PropertyRegistrar.kt
+++ b/src/main/kotlin/computer/obscure/twine/nativex/PropertyRegistrar.kt
@@ -42,7 +42,8 @@ class PropertyRegistrar(private val owner: TwineNative) {
                         name = name,
                         getter = getter,
                         setter = setter,
-                        defaultValue = defaultValue
+                        defaultValue = defaultValue,
+                        type = prop.returnType
                     )
                 }
                 .toMap()

--- a/src/main/kotlin/computer/obscure/twine/nativex/classes/NativeProperty.kt
+++ b/src/main/kotlin/computer/obscure/twine/nativex/classes/NativeProperty.kt
@@ -1,10 +1,12 @@
 package computer.obscure.twine.nativex.classes
 
 import kotlin.reflect.KFunction
+import kotlin.reflect.KType
 
 data class NativeProperty(
     val name: String,
     val getter: KFunction<*>,
     val setter: KFunction<*>?,
-    val defaultValue: Any?
+    val defaultValue: Any?,
+    val type: KType
 )

--- a/src/test/kotlin/computer/obscure/twine/TwineConstructorTest.kt
+++ b/src/test/kotlin/computer/obscure/twine/TwineConstructorTest.kt
@@ -1,0 +1,48 @@
+package computer.obscure.twine
+
+import computer.obscure.twine.annotations.TwineNativeFunction
+import computer.obscure.twine.annotations.TwineNativeProperty
+import computer.obscure.twine.nativex.TwineEngine
+import computer.obscure.twine.nativex.TwineNative
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+
+@Suppress("unused")
+class TwineConstructorTestClass(
+    @TwineNativeProperty
+    val test: Int
+) : TwineNative("class1") {
+    @TwineNativeFunction
+    fun class2(): TwineConstructorTestClass2 {
+        return TwineConstructorTestClass2(this)
+    }
+}
+
+@Suppress("unused")
+class TwineConstructorTestClass2(
+    @TwineNativeProperty
+    var class1: TwineConstructorTestClass
+) : TwineNative() {
+    @TwineNativeProperty
+    val works = true
+}
+
+class TwineIDKTest {
+    fun run(script: String): Any {
+        val engine = TwineEngine()
+
+        engine.set(TwineConstructorTestClass(2))
+
+        return engine
+            .run("test.lua", script)
+            .getOrThrow()
+    }
+
+    @Test
+    fun `test should return a String type when a string is passed to it`() {
+        val result = run("return class1.class2().works").toString()
+
+        assertEquals("true", result)
+    }
+}

--- a/src/test/kotlin/computer/obscure/twine/TwineNativeTest.kt
+++ b/src/test/kotlin/computer/obscure/twine/TwineNativeTest.kt
@@ -27,11 +27,6 @@ class TwineNativeTestClass: TwineNative() {
     fun testCallback(time: Long, callback: (time: Long) -> String): String {
         return callback(time).toLuaValue().toString()
     }
-
-    @TwineNativeFunction
-    fun testNew() {
-        println("new")
-    }
 }
 
 class TwineNativeTest {
@@ -57,7 +52,7 @@ class TwineNativeTest {
     fun `testVarargDouble should print the sum of all arguments`() {
         val result = run("return test.testVarargDouble(1, 2, 3)")
 
-        assertEquals(6, result.toString().toInt())
+        assertEquals(6.0, result.toString().toDouble())
     }
 
     @Test
@@ -76,15 +71,5 @@ class TwineNativeTest {
         """)
 
         assertEquals("50", result.toString())
-    }
-
-    @Test
-    fun `testNew should create a new test object`() {
-        val result = run("""
-            return test.testNew()
-        """)
-
-        println(result)
-//        assertEquals("50", result.toString())
     }
 }

--- a/src/test/kotlin/computer/obscure/twine/TwineOverloadTest.kt
+++ b/src/test/kotlin/computer/obscure/twine/TwineOverloadTest.kt
@@ -6,6 +6,7 @@ import computer.obscure.twine.annotations.TwineOverload
 import computer.obscure.twine.nativex.TwineEngine
 import computer.obscure.twine.nativex.TwineNative
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 
 
@@ -47,7 +48,6 @@ class TwineOverloadTest {
 
         engine.set(TwineOverloadTestClass())
 
-        TwineLogger.level = TwineLogger.DEBUG
         return engine
             .run("test.lua", script)
             .getOrThrow()
@@ -72,5 +72,17 @@ class TwineOverloadTest {
         val result = run("return class1.test(class1.class2()).works").toString()
 
         assertEquals(true, result.toBoolean())
+    }
+
+    @Test
+    fun `test should throw an error when no matching overload`() {
+        val result = assertThrows<TwineError> {
+            run("return class1.test(false)")
+        }
+
+        assertEquals(
+            true,
+            result.message?.startsWith("No matching overload found")
+        )
     }
 }


### PR DESCRIPTION
- varargs are fixed, supporting most major types (double, int, bool, long, float, string, anything else that has a java equivalent)
- chaining of natives are fixed (I lied the first time)
  - through this fix, passing natives in constructors also works now

All tests now pass!